### PR TITLE
feat: use @napi-rs/canvas instead node-canvas

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mcp-echarts",
   "description": "❤️ Generate visual charts using Apache ECharts with AI MCP dynamically.",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "main": "build/index.js",
   "scripts": {
     "test": "vitest",

--- a/package.json
+++ b/package.json
@@ -14,11 +14,11 @@
   "bin": {
     "mcp-echarts": "./build/index.js"
   },
-  "files": ["build"],
+  "files": ["build", "public"],
   "keywords": ["mcp", "echarts", "visualization", "chart", "mcp-echarts"],
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.0",
-    "canvas": "3.1.2",
+    "@napi-rs/canvas": "^0.1.73",
     "echarts": "^5.6.0",
     "zod": "^3.25.16"
   },

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "bin": {
     "mcp-echarts": "./build/index.js"
   },
-  "files": ["build", "public"],
+  "files": ["build", "fonts"],
   "keywords": ["mcp", "echarts", "visualization", "chart", "mcp-echarts"],
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.0",

--- a/src/utils/render.ts
+++ b/src/utils/render.ts
@@ -1,6 +1,18 @@
-import { createCanvas } from "canvas";
+import path from "node:path";
+import { GlobalFonts, createCanvas } from "@napi-rs/canvas";
 import * as echarts from "echarts";
 import type { EChartsOption } from "echarts";
+
+const fontPath = path.join(
+  __dirname,
+  "..",
+  "..",
+  "public",
+  "fonts",
+  "SourceHanSansSC-VF.otf",
+);
+
+GlobalFonts.registerFromPath(fontPath, "sans-serif");
 
 export function renderECharts(
   echartsOption: EChartsOption,

--- a/src/utils/render.ts
+++ b/src/utils/render.ts
@@ -7,9 +7,8 @@ const fontPath = path.join(
   __dirname,
   "..",
   "..",
-  "public",
   "fonts",
-  "SourceHanSansSC-VF.otf",
+  "AlibabaPuHuiTi-3-55-Regular.otf",
 );
 
 GlobalFonts.registerFromPath(fontPath, "sans-serif");


### PR DESCRIPTION
- use @napi-rs/canvas instead node-canvas
- Add public to the files in package.json to ensure that the release package contains the font file
- fixed: https://github.com/hustcc/mcp-echarts/issues/1

### problem
Chinese font files are too large (A Chinese font file takes 30 MB) and download speed is slow, so the best way may be to get the font files through CDN.
- The current solution is only a temporary solution.
- Later, the font file needs to be sliced to reduce the font file size



