### PR TITLE
feat: add `outputType` schema for all chart tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ npm run start
 - [2niuhe](https://github.com/2niuhe): Support MCP with SSE and Streaming HTTP. [#17](https://github.com/hustcc/mcp-echarts/issues/17)
 - [susuperli](https://github.com/susuperli): Use `MinIO` to save the chart image base64 and return the url. [#10](https://github.com/hustcc/mcp-echarts/issues/10)
 - [BQXBQX](https://github.com/BQXBQX): Use `@napi-rs/canvas` instead node-canvas. [#3](https://github.com/hustcc/mcp-echarts/issues/3)
+- [Meet-student](https://github.com/Meet-student): Add `outputType` schema for all chart tools. [#24](https://github.com/hustcc/mcp-echarts/issues/24)
 - [hustcc](https://github.com/hustcc): Initial the repo.
 
 

--- a/__tests__/schema/bar.json
+++ b/__tests__/schema/bar.json
@@ -68,6 +68,12 @@
         "exclusiveMinimum": 0,
         "default": 800,
         "description": "Set the width of the chart, default is 800px."
+      },
+      "outputType": {
+        "type": "string",
+        "enum": ["png", "svg", "option"],
+        "default": "png",
+        "description": "The output type of the diagram. Can be 'png', 'svg' or 'option'. Default is 'png', 'png' will return the rendered PNG image, 'svg' will return the rendered SVG string, and 'option' will return the valid ECharts option."
       }
     },
     "required": ["data"],

--- a/__tests__/schema/boxplot.json
+++ b/__tests__/schema/boxplot.json
@@ -58,6 +58,12 @@
         "exclusiveMinimum": 0,
         "default": 800,
         "description": "Set the width of the chart, default is 800px."
+      },
+      "outputType": {
+        "type": "string",
+        "enum": ["png", "svg", "option"],
+        "default": "png",
+        "description": "The output type of the diagram. Can be 'png', 'svg' or 'option'. Default is 'png', 'png' will return the rendered PNG image, 'svg' will return the rendered SVG string, and 'option' will return the valid ECharts option."
       }
     },
     "required": ["data"],

--- a/__tests__/schema/candlestick.json
+++ b/__tests__/schema/candlestick.json
@@ -65,6 +65,12 @@
         "exclusiveMinimum": 0,
         "default": 800,
         "description": "Set the width of the chart, default is 800px."
+      },
+      "outputType": {
+        "type": "string",
+        "enum": ["png", "svg", "option"],
+        "default": "png",
+        "description": "The output type of the diagram. Can be 'png', 'svg' or 'option'. Default is 'png', 'png' will return the rendered PNG image, 'svg' will return the rendered SVG string, and 'option' will return the valid ECharts option."
       }
     },
     "required": ["data"],

--- a/__tests__/schema/funnel.json
+++ b/__tests__/schema/funnel.json
@@ -44,6 +44,12 @@
         "exclusiveMinimum": 0,
         "default": 800,
         "description": "Set the width of the chart, default is 800px."
+      },
+      "outputType": {
+        "type": "string",
+        "enum": ["png", "svg", "option"],
+        "default": "png",
+        "description": "The output type of the diagram. Can be 'png', 'svg' or 'option'. Default is 'png', 'png' will return the rendered PNG image, 'svg' will return the rendered SVG string, and 'option' will return the valid ECharts option."
       }
     },
     "required": ["data"],

--- a/__tests__/schema/gauge.json
+++ b/__tests__/schema/gauge.json
@@ -54,6 +54,12 @@
         "exclusiveMinimum": 0,
         "default": 800,
         "description": "Set the width of the chart, default is 800px."
+      },
+      "outputType": {
+        "type": "string",
+        "enum": ["png", "svg", "option"],
+        "default": "png",
+        "description": "The output type of the diagram. Can be 'png', 'svg' or 'option'. Default is 'png', 'png' will return the rendered PNG image, 'svg' will return the rendered SVG string, and 'option' will return the valid ECharts option."
       }
     },
     "required": ["data"],

--- a/__tests__/schema/graph.json
+++ b/__tests__/schema/graph.json
@@ -88,6 +88,12 @@
         "exclusiveMinimum": 0,
         "default": 800,
         "description": "Set the width of the chart, default is 800px."
+      },
+      "outputType": {
+        "type": "string",
+        "enum": ["png", "svg", "option"],
+        "default": "png",
+        "description": "The output type of the diagram. Can be 'png', 'svg' or 'option'. Default is 'png', 'png' will return the rendered PNG image, 'svg' will return the rendered SVG string, and 'option' will return the valid ECharts option."
       }
     },
     "required": ["data"],

--- a/__tests__/schema/heatmap.json
+++ b/__tests__/schema/heatmap.json
@@ -58,6 +58,12 @@
         "exclusiveMinimum": 0,
         "default": 800,
         "description": "Set the width of the chart, default is 800px."
+      },
+      "outputType": {
+        "type": "string",
+        "enum": ["png", "svg", "option"],
+        "default": "png",
+        "description": "The output type of the diagram. Can be 'png', 'svg' or 'option'. Default is 'png', 'png' will return the rendered PNG image, 'svg' will return the rendered SVG string, and 'option' will return the valid ECharts option."
       }
     },
     "required": ["data"],

--- a/__tests__/schema/line.json
+++ b/__tests__/schema/line.json
@@ -76,6 +76,12 @@
         "exclusiveMinimum": 0,
         "default": 800,
         "description": "Set the width of the chart, default is 800px."
+      },
+      "outputType": {
+        "type": "string",
+        "enum": ["png", "svg", "option"],
+        "default": "png",
+        "description": "The output type of the diagram. Can be 'png', 'svg' or 'option'. Default is 'png', 'png' will return the rendered PNG image, 'svg' will return the rendered SVG string, and 'option' will return the valid ECharts option."
       }
     },
     "required": ["data"],

--- a/__tests__/schema/parallel.json
+++ b/__tests__/schema/parallel.json
@@ -55,6 +55,12 @@
         "exclusiveMinimum": 0,
         "default": 800,
         "description": "Set the width of the chart, default is 800px."
+      },
+      "outputType": {
+        "type": "string",
+        "enum": ["png", "svg", "option"],
+        "default": "png",
+        "description": "The output type of the diagram. Can be 'png', 'svg' or 'option'. Default is 'png', 'png' will return the rendered PNG image, 'svg' will return the rendered SVG string, and 'option' will return the valid ECharts option."
       }
     },
     "required": ["data", "dimensions"],

--- a/__tests__/schema/pie.json
+++ b/__tests__/schema/pie.json
@@ -49,6 +49,12 @@
         "exclusiveMinimum": 0,
         "default": 800,
         "description": "Set the width of the chart, default is 800px."
+      },
+      "outputType": {
+        "type": "string",
+        "enum": ["png", "svg", "option"],
+        "default": "png",
+        "description": "The output type of the diagram. Can be 'png', 'svg' or 'option'. Default is 'png', 'png' will return the rendered PNG image, 'svg' will return the rendered SVG string, and 'option' will return the valid ECharts option."
       }
     },
     "required": ["data"],

--- a/__tests__/schema/radar.json
+++ b/__tests__/schema/radar.json
@@ -48,6 +48,12 @@
         "exclusiveMinimum": 0,
         "default": 800,
         "description": "Set the width of the chart, default is 800px."
+      },
+      "outputType": {
+        "type": "string",
+        "enum": ["png", "svg", "option"],
+        "default": "png",
+        "description": "The output type of the diagram. Can be 'png', 'svg' or 'option'. Default is 'png', 'png' will return the rendered PNG image, 'svg' will return the rendered SVG string, and 'option' will return the valid ECharts option."
       }
     },
     "required": ["data"],

--- a/__tests__/schema/sankey.json
+++ b/__tests__/schema/sankey.json
@@ -54,6 +54,12 @@
         "exclusiveMinimum": 0,
         "default": 800,
         "description": "Set the width of the chart, default is 800px."
+      },
+      "outputType": {
+        "type": "string",
+        "enum": ["png", "svg", "option"],
+        "default": "png",
+        "description": "The output type of the diagram. Can be 'png', 'svg' or 'option'. Default is 'png', 'png' will return the rendered PNG image, 'svg' will return the rendered SVG string, and 'option' will return the valid ECharts option."
       }
     },
     "required": ["data"],

--- a/__tests__/schema/scatter.json
+++ b/__tests__/schema/scatter.json
@@ -54,6 +54,12 @@
         "exclusiveMinimum": 0,
         "default": 800,
         "description": "Set the width of the chart, default is 800px."
+      },
+      "outputType": {
+        "type": "string",
+        "enum": ["png", "svg", "option"],
+        "default": "png",
+        "description": "The output type of the diagram. Can be 'png', 'svg' or 'option'. Default is 'png', 'png' will return the rendered PNG image, 'svg' will return the rendered SVG string, and 'option' will return the valid ECharts option."
       }
     },
     "required": ["data"],

--- a/__tests__/schema/sunburst.json
+++ b/__tests__/schema/sunburst.json
@@ -51,6 +51,12 @@
         "exclusiveMinimum": 0,
         "default": 800,
         "description": "Set the width of the chart, default is 800px."
+      },
+      "outputType": {
+        "type": "string",
+        "enum": ["png", "svg", "option"],
+        "default": "png",
+        "description": "The output type of the diagram. Can be 'png', 'svg' or 'option'. Default is 'png', 'png' will return the rendered PNG image, 'svg' will return the rendered SVG string, and 'option' will return the valid ECharts option."
       }
     },
     "required": ["data"],

--- a/__tests__/schema/tree.json
+++ b/__tests__/schema/tree.json
@@ -77,6 +77,12 @@
         "exclusiveMinimum": 0,
         "default": 800,
         "description": "Set the width of the chart, default is 800px."
+      },
+      "outputType": {
+        "type": "string",
+        "enum": ["png", "svg", "option"],
+        "default": "png",
+        "description": "The output type of the diagram. Can be 'png', 'svg' or 'option'. Default is 'png', 'png' will return the rendered PNG image, 'svg' will return the rendered SVG string, and 'option' will return the valid ECharts option."
       }
     },
     "required": ["data"],

--- a/__tests__/schema/treemap.json
+++ b/__tests__/schema/treemap.json
@@ -51,6 +51,12 @@
         "exclusiveMinimum": 0,
         "default": 800,
         "description": "Set the width of the chart, default is 800px."
+      },
+      "outputType": {
+        "type": "string",
+        "enum": ["png", "svg", "option"],
+        "default": "png",
+        "description": "The output type of the diagram. Can be 'png', 'svg' or 'option'. Default is 'png', 'png' will return the rendered PNG image, 'svg' will return the rendered SVG string, and 'option' will return the valid ECharts option."
       }
     },
     "required": ["data"],

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mcp-echarts",
   "description": "❤️ Generate visual charts using Apache ECharts with AI MCP dynamically.",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "main": "build/index.js",
   "scripts": {
     "test": "vitest",

--- a/src/tools/bar.ts
+++ b/src/tools/bar.ts
@@ -5,6 +5,7 @@ import {
   AxisXTitleSchema,
   AxisYTitleSchema,
   HeightSchema,
+  OutputTypeSchema,
   ThemeSchema,
   TitleSchema,
   WidthSchema,
@@ -54,6 +55,7 @@ export const generateBarChartTool = {
     theme: ThemeSchema,
     title: TitleSchema,
     width: WidthSchema,
+    outputType: OutputTypeSchema,
   }),
   run: async (params: {
     axisXTitle?: string;
@@ -65,6 +67,7 @@ export const generateBarChartTool = {
     theme?: "default" | "dark";
     title?: string;
     width: number;
+    outputType?: "png" | "svg" | "option";
   }) => {
     const {
       axisXTitle,
@@ -76,6 +79,7 @@ export const generateBarChartTool = {
       theme,
       title,
       width,
+      outputType,
     } = params;
 
     // Check if data has group field for multiple series
@@ -169,7 +173,7 @@ export const generateBarChartTool = {
       width,
       height,
       theme,
-      "png",
+      outputType,
       "generate_bar_chart",
     );
   },

--- a/src/tools/boxplot.ts
+++ b/src/tools/boxplot.ts
@@ -5,6 +5,7 @@ import {
   AxisXTitleSchema,
   AxisYTitleSchema,
   HeightSchema,
+  OutputTypeSchema,
   ThemeSchema,
   TitleSchema,
   WidthSchema,
@@ -41,6 +42,7 @@ export const generateBoxplotChartTool = {
     theme: ThemeSchema,
     title: TitleSchema,
     width: WidthSchema,
+    outputType: OutputTypeSchema,
   }),
   run: async (params: {
     axisXTitle?: string;
@@ -50,9 +52,18 @@ export const generateBoxplotChartTool = {
     theme?: "default" | "dark";
     title?: string;
     width: number;
+    outputType?: "png" | "svg" | "option";
   }) => {
-    const { axisXTitle, axisYTitle, data, height, theme, title, width } =
-      params;
+    const {
+      axisXTitle,
+      axisYTitle,
+      data,
+      height,
+      theme,
+      title,
+      width,
+      outputType,
+    } = params;
 
     // Group data by category and optional group
     const hasGroups = data.some((item) => item.group);
@@ -186,7 +197,7 @@ export const generateBoxplotChartTool = {
       width,
       height,
       theme,
-      "png",
+      outputType,
       "generate_boxplot_chart",
     );
   },

--- a/src/tools/candlestick.ts
+++ b/src/tools/candlestick.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { generateChartImage } from "../utils";
 import {
   HeightSchema,
+  OutputTypeSchema,
   ThemeSchema,
   TitleSchema,
   WidthSchema,
@@ -40,6 +41,7 @@ export const generateCandlestickChartTool = {
     theme: ThemeSchema,
     title: TitleSchema,
     width: WidthSchema,
+    outputType: OutputTypeSchema,
   }),
   run: async (params: {
     data: Array<{
@@ -55,8 +57,17 @@ export const generateCandlestickChartTool = {
     theme?: "default" | "dark";
     title?: string;
     width: number;
+    outputType?: "png" | "svg" | "option";
   }) => {
-    const { data, height, showVolume = false, theme, title, width } = params;
+    const {
+      data,
+      height,
+      showVolume = false,
+      theme,
+      title,
+      width,
+      outputType,
+    } = params;
 
     // Sort data by date
     const sortedData = [...data].sort(
@@ -216,7 +227,7 @@ export const generateCandlestickChartTool = {
       width,
       height,
       theme,
-      "png",
+      outputType,
       "generate_candlestick_chart",
     );
   },

--- a/src/tools/echarts.ts
+++ b/src/tools/echarts.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { generateChartImage } from "../utils";
+import { OutputTypeSchema } from "../utils/schema";
 
 function isValidEChartsOption(option: string): boolean {
   try {
@@ -89,13 +90,7 @@ ATTENTION: A valid ECharts option must be a valid JSON string, and cannot be emp
       .describe("ECharts theme, optional. Default is 'default'.")
       .optional()
       .default("default"),
-    outputType: z
-      .enum(["png", "svg", "option"])
-      .describe(
-        "The output type of the diagram. Can be 'png', 'svg' or 'option'. Default is 'png', 'png' will return the rendered PNG image, 'svg' will return the rendered SVG string, and 'option' will return the valid ECharts option.",
-      )
-      .optional()
-      .default("png"),
+    outputType: OutputTypeSchema,
   }),
   run: async (params: {
     echartsOption: string;

--- a/src/tools/funnel.ts
+++ b/src/tools/funnel.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { generateChartImage } from "../utils";
 import {
   HeightSchema,
+  OutputTypeSchema,
   ThemeSchema,
   TitleSchema,
   WidthSchema,
@@ -31,6 +32,7 @@ export const generateFunnelChartTool = {
     theme: ThemeSchema,
     title: TitleSchema,
     width: WidthSchema,
+    outputType: OutputTypeSchema,
   }),
   run: async (params: {
     data: Array<{ category: string; value: number }>;
@@ -38,8 +40,9 @@ export const generateFunnelChartTool = {
     theme?: "default" | "dark";
     title?: string;
     width: number;
+    outputType?: "png" | "svg" | "option";
   }) => {
-    const { data, height, theme, title, width } = params;
+    const { data, height, theme, title, width, outputType } = params;
 
     // Transform data for ECharts funnel chart
     const funnelData = data.map((item) => ({
@@ -108,7 +111,7 @@ export const generateFunnelChartTool = {
       width,
       height,
       theme,
-      "png",
+      outputType,
       "generate_funnel_chart",
     );
   },

--- a/src/tools/gauge.ts
+++ b/src/tools/gauge.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { generateChartImage } from "../utils";
 import {
   HeightSchema,
+  OutputTypeSchema,
   ThemeSchema,
   TitleSchema,
   WidthSchema,
@@ -39,6 +40,7 @@ export const generateGaugeChartTool = {
     theme: ThemeSchema,
     title: TitleSchema,
     width: WidthSchema,
+    outputType: OutputTypeSchema,
   }),
   run: async (params: {
     data: Array<{ name: string; value: number }>;
@@ -48,8 +50,18 @@ export const generateGaugeChartTool = {
     theme?: "default" | "dark";
     title?: string;
     width: number;
+    outputType?: "png" | "svg" | "option";
   }) => {
-    const { data, height, max = 100, min = 0, theme, title, width } = params;
+    const {
+      data,
+      height,
+      max = 100,
+      min = 0,
+      theme,
+      title,
+      width,
+      outputType,
+    } = params;
 
     // For multiple gauges, arrange them horizontally
     const series: Array<SeriesOption> = data.map((item, index) => {
@@ -140,7 +152,7 @@ export const generateGaugeChartTool = {
       width,
       height,
       theme,
-      "png",
+      outputType,
       "generate_gauge_chart",
     );
   },

--- a/src/tools/graph.ts
+++ b/src/tools/graph.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { generateChartImage } from "../utils";
 import {
   HeightSchema,
+  OutputTypeSchema,
   ThemeSchema,
   TitleSchema,
   WidthSchema,
@@ -58,6 +59,7 @@ export const generateGraphChartTool = {
     theme: ThemeSchema,
     title: TitleSchema,
     width: WidthSchema,
+    outputType: OutputTypeSchema,
   }),
   run: async (params: {
     data: {
@@ -74,8 +76,17 @@ export const generateGraphChartTool = {
     theme?: "default" | "dark";
     title?: string;
     width: number;
+    outputType?: "png" | "svg" | "option";
   }) => {
-    const { data, height, layout = "force", theme, title, width } = params;
+    const {
+      data,
+      height,
+      layout = "force",
+      theme,
+      title,
+      width,
+      outputType,
+    } = params;
 
     // Validate that all edge nodes exist in nodes array
     const nodeIds = new Set(data.nodes.map((node) => node.id));
@@ -168,7 +179,7 @@ export const generateGraphChartTool = {
       width,
       height,
       theme,
-      "png",
+      outputType,
       "generate_graph_chart",
     );
   },

--- a/src/tools/heatmap.ts
+++ b/src/tools/heatmap.ts
@@ -5,6 +5,7 @@ import {
   AxisXTitleSchema,
   AxisYTitleSchema,
   HeightSchema,
+  OutputTypeSchema,
   ThemeSchema,
   TitleSchema,
   WidthSchema,
@@ -38,6 +39,7 @@ export const generateHeatmapChartTool = {
     theme: ThemeSchema,
     title: TitleSchema,
     width: WidthSchema,
+    outputType: OutputTypeSchema,
   }),
   run: async (params: {
     axisXTitle?: string;
@@ -47,9 +49,18 @@ export const generateHeatmapChartTool = {
     theme?: "default" | "dark";
     title?: string;
     width: number;
+    outputType?: "png" | "svg" | "option";
   }) => {
-    const { axisXTitle, axisYTitle, data, height, theme, title, width } =
-      params;
+    const {
+      axisXTitle,
+      axisYTitle,
+      data,
+      height,
+      theme,
+      title,
+      width,
+      outputType,
+    } = params;
 
     // Extract unique x and y values
     const xValues = Array.from(new Set(data.map((item) => item.x))).sort();
@@ -154,7 +165,7 @@ export const generateHeatmapChartTool = {
       width,
       height,
       theme,
-      "png",
+      outputType,
       "generate_heatmap_chart",
     );
   },

--- a/src/tools/line.ts
+++ b/src/tools/line.ts
@@ -5,6 +5,7 @@ import {
   AxisXTitleSchema,
   AxisYTitleSchema,
   HeightSchema,
+  OutputTypeSchema,
   ThemeSchema,
   TitleSchema,
   WidthSchema,
@@ -59,6 +60,7 @@ export const generateLineChartTool = {
     theme: ThemeSchema,
     title: TitleSchema,
     width: WidthSchema,
+    outputType: OutputTypeSchema,
   }),
   run: (params: {
     axisXTitle?: string;
@@ -72,6 +74,7 @@ export const generateLineChartTool = {
     theme?: "default" | "dark";
     title?: string;
     width: number;
+    outputType?: "png" | "svg" | "option";
   }) => {
     const {
       axisXTitle,
@@ -85,6 +88,7 @@ export const generateLineChartTool = {
       theme,
       title,
       width,
+      outputType,
     } = params;
 
     // Check if data has group field for multiple series
@@ -186,7 +190,7 @@ export const generateLineChartTool = {
       width,
       height,
       theme,
-      "png",
+      outputType,
       "generate_line_chart",
     );
   },

--- a/src/tools/parallel.ts
+++ b/src/tools/parallel.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { generateChartImage } from "../utils";
 import {
   HeightSchema,
+  OutputTypeSchema,
   ThemeSchema,
   TitleSchema,
   WidthSchema,
@@ -35,6 +36,7 @@ export const generateParallelChartTool = {
     theme: ThemeSchema,
     title: TitleSchema,
     width: WidthSchema,
+    outputType: OutputTypeSchema,
   }),
   run: async (params: {
     data: Array<{ name: string; values: number[] }>;
@@ -43,8 +45,10 @@ export const generateParallelChartTool = {
     theme?: "default" | "dark";
     title?: string;
     width: number;
+    outputType?: "png" | "svg" | "option";
   }) => {
-    const { data, dimensions, height, theme, title, width } = params;
+    const { data, dimensions, height, theme, title, width, outputType } =
+      params;
 
     // Calculate min/max for each dimension
     const parallelAxis = dimensions.map((dim, index) => {
@@ -138,7 +142,7 @@ export const generateParallelChartTool = {
       width,
       height,
       theme,
-      "png",
+      outputType,
       "generate_parallel_chart",
     );
   },

--- a/src/tools/pie.ts
+++ b/src/tools/pie.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { generateChartImage } from "../utils";
 import {
   HeightSchema,
+  OutputTypeSchema,
   ThemeSchema,
   TitleSchema,
   WidthSchema,
@@ -37,6 +38,7 @@ export const generatePieChartTool = {
     theme: ThemeSchema,
     title: TitleSchema,
     width: WidthSchema,
+    outputType: OutputTypeSchema,
   }),
   run: async (params: {
     data: Array<{ category: string; value: number }>;
@@ -45,8 +47,17 @@ export const generatePieChartTool = {
     theme?: "default" | "dark";
     title?: string;
     width: number;
+    outputType?: "png" | "svg" | "option";
   }) => {
-    const { data, height, innerRadius = 0, theme, title, width } = params;
+    const {
+      data,
+      height,
+      innerRadius = 0,
+      theme,
+      title,
+      width,
+      outputType,
+    } = params;
 
     // Transform data for ECharts
     const pieData = data.map((item) => ({
@@ -91,7 +102,7 @@ export const generatePieChartTool = {
       width,
       height,
       theme,
-      "png",
+      outputType,
       "generate_pie_chart",
     );
   },

--- a/src/tools/radar.ts
+++ b/src/tools/radar.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { generateChartImage } from "../utils";
 import {
   HeightSchema,
+  OutputTypeSchema,
   ThemeSchema,
   TitleSchema,
   WidthSchema,
@@ -35,6 +36,7 @@ export const generateRadarChartTool = {
     theme: ThemeSchema,
     title: TitleSchema,
     width: WidthSchema,
+    outputType: OutputTypeSchema,
   }),
   run: async (params: {
     data: Array<{ name: string; value: number; group?: string }>;
@@ -42,8 +44,9 @@ export const generateRadarChartTool = {
     theme?: "default" | "dark";
     title?: string;
     width: number;
+    outputType?: "png" | "svg" | "option";
   }) => {
-    const { data, height, theme, title, width } = params;
+    const { data, height, theme, title, width, outputType } = params;
 
     // Check if data has group field for multiple series
     const hasGroups = data.some((item) => item.group);
@@ -167,7 +170,7 @@ export const generateRadarChartTool = {
       width,
       height,
       theme,
-      "png",
+      outputType,
       "generate_radar_chart",
     );
   },

--- a/src/tools/sankey.ts
+++ b/src/tools/sankey.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { generateChartImage } from "../utils";
 import {
   HeightSchema,
+  OutputTypeSchema,
   ThemeSchema,
   TitleSchema,
   WidthSchema,
@@ -39,6 +40,7 @@ export const generateSankeyChartTool = {
     theme: ThemeSchema,
     title: TitleSchema,
     width: WidthSchema,
+    outputType: OutputTypeSchema,
   }),
   run: async (params: {
     data: Array<{ source: string; target: string; value: number }>;
@@ -47,8 +49,17 @@ export const generateSankeyChartTool = {
     theme?: "default" | "dark";
     title?: string;
     width: number;
+    outputType?: "png" | "svg" | "option";
   }) => {
-    const { data, height, nodeAlign = "justify", theme, title, width } = params;
+    const {
+      data,
+      height,
+      nodeAlign = "justify",
+      theme,
+      title,
+      width,
+      outputType,
+    } = params;
 
     // Extract unique nodes from data
     const nodeSet = new Set<string>();
@@ -108,7 +119,7 @@ export const generateSankeyChartTool = {
       width,
       height,
       theme,
-      "png",
+      outputType,
       "generate_sankey_chart",
     );
   },

--- a/src/tools/scatter.ts
+++ b/src/tools/scatter.ts
@@ -5,6 +5,7 @@ import {
   AxisXTitleSchema,
   AxisYTitleSchema,
   HeightSchema,
+  OutputTypeSchema,
   ThemeSchema,
   TitleSchema,
   WidthSchema,
@@ -33,6 +34,7 @@ export const generateScatterChartTool = {
     theme: ThemeSchema,
     title: TitleSchema,
     width: WidthSchema,
+    outputType: OutputTypeSchema,
   }),
   run: async (params: {
     axisXTitle?: string;
@@ -42,9 +44,18 @@ export const generateScatterChartTool = {
     theme?: "default" | "dark";
     title?: string;
     width: number;
+    outputType?: "png" | "svg" | "option";
   }) => {
-    const { axisXTitle, axisYTitle, data, height, theme, title, width } =
-      params;
+    const {
+      axisXTitle,
+      axisYTitle,
+      data,
+      height,
+      theme,
+      title,
+      width,
+      outputType,
+    } = params;
 
     // Transform data for ECharts scatter chart
     const scatterData = data.map((item) => [item.x, item.y]);
@@ -91,7 +102,7 @@ export const generateScatterChartTool = {
       width,
       height,
       theme,
-      "png",
+      outputType,
       "generate_scatter_chart",
     );
   },

--- a/src/tools/sunburst.ts
+++ b/src/tools/sunburst.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { generateChartImage } from "../utils";
 import {
   HeightSchema,
+  OutputTypeSchema,
   ThemeSchema,
   TitleSchema,
   WidthSchema,
@@ -42,6 +43,7 @@ export const generateSunburstChartTool = {
     theme: ThemeSchema,
     title: TitleSchema,
     width: WidthSchema,
+    outputType: OutputTypeSchema,
   }),
   run: async (params: {
     data: Array<SunburstDataType>;
@@ -49,8 +51,9 @@ export const generateSunburstChartTool = {
     theme?: "default" | "dark";
     title?: string;
     width: number;
+    outputType?: "png" | "svg" | "option";
   }) => {
-    const { data, height, theme, title, width } = params;
+    const { data, height, theme, title, width, outputType } = params;
 
     const series: Array<SeriesOption> = [
       {
@@ -124,7 +127,7 @@ export const generateSunburstChartTool = {
       width,
       height,
       theme,
-      "png",
+      outputType,
       "generate_sunburst_chart",
     );
   },

--- a/src/tools/tree.ts
+++ b/src/tools/tree.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { generateChartImage } from "../utils";
 import {
   HeightSchema,
+  OutputTypeSchema,
   ThemeSchema,
   TitleSchema,
   WidthSchema,
@@ -51,6 +52,7 @@ export const generateTreeChartTool = {
     theme: ThemeSchema,
     title: TitleSchema,
     width: WidthSchema,
+    outputType: OutputTypeSchema,
   }),
   run: async (params: {
     data: TreeDataType;
@@ -60,6 +62,7 @@ export const generateTreeChartTool = {
     theme?: "default" | "dark";
     title?: string;
     width: number;
+    outputType?: "png" | "svg" | "option";
   }) => {
     const {
       data,
@@ -69,6 +72,7 @@ export const generateTreeChartTool = {
       theme,
       title,
       width,
+      outputType,
     } = params;
 
     const series: Array<SeriesOption> = [
@@ -160,7 +164,7 @@ export const generateTreeChartTool = {
       width,
       height,
       theme,
-      "png",
+      outputType,
       "generate_tree_chart",
     );
   },

--- a/src/tools/treemap.ts
+++ b/src/tools/treemap.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { generateChartImage } from "../utils";
 import {
   HeightSchema,
+  OutputTypeSchema,
   ThemeSchema,
   TitleSchema,
   WidthSchema,
@@ -42,6 +43,7 @@ export const generateTreemapChartTool = {
     theme: ThemeSchema,
     title: TitleSchema,
     width: WidthSchema,
+    outputType: OutputTypeSchema,
   }),
   run: async (params: {
     data: Array<TreemapDataType>;
@@ -49,8 +51,9 @@ export const generateTreemapChartTool = {
     theme?: "default" | "dark";
     title?: string;
     width: number;
+    outputType?: "png" | "svg" | "option";
   }) => {
-    const { data, height, theme, title, width } = params;
+    const { data, height, theme, title, width, outputType } = params;
 
     const series: Array<SeriesOption> = [
       {
@@ -125,7 +128,7 @@ export const generateTreemapChartTool = {
       width,
       height,
       theme,
-      "png",
+      outputType,
       "generate_treemap_chart",
     );
   },

--- a/src/utils/schema.ts
+++ b/src/utils/schema.ts
@@ -27,6 +27,14 @@ export const ThemeSchema = z
   .default("default")
   .describe("Set the theme for the chart, optional, default is 'default'.");
 
+export const OutputTypeSchema = z
+  .enum(["png", "svg", "option"])
+  .optional()
+  .default("png")
+  .describe(
+    "The output type of the diagram. Can be 'png', 'svg' or 'option'. Default is 'png', 'png' will return the rendered PNG image, 'svg' will return the rendered SVG string, and 'option' will return the valid ECharts option.",
+  );
+
 export const TitleSchema = z
   .string()
   .optional()


### PR DESCRIPTION

### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [x] ❓ Other (about what?)

### 🔗 Related Issues

> - close #23

### 💡 Background and Solution

> - Add all chart outputType schame

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Add all chart outputType schame      |
| 🇨🇳 Chinese |  Add all chart outputType schame       |
