### PR TITLE
feat(server) : add health check endpoint for both SSE and streamable HTTP server

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -91,6 +91,13 @@ async function main(): Promise<void> {
   }
 }
 
+// Add health check endpoint to app
+function addHealthCheck(app: express.Express): void {
+  app.get("/health", (_, res) =>
+    res.json({ status: "healthy", service: "mcp-echarts" }),
+  );
+}
+
 async function runStdioServer(): Promise<void> {
   const server = createEChartsServer();
   const transport = new StdioServerTransport();
@@ -127,6 +134,8 @@ async function runSSEServer(port: number, endpoint: string): Promise<void> {
       res.status(400).send("No transport found for sessionId");
     }
   });
+  // Health check endpoint for SSE
+  addHealthCheck(app);
 
   app.listen(port, () => {
     console.log(
@@ -211,6 +220,8 @@ async function runStreamableHTTPServer(
     const transport = transports[sessionId];
     await transport.handleRequest(req, res);
   });
+  // Health check point for Streamable HTTP
+  addHealthCheck(app);
 
   app.listen(port, () => {
     console.log(


### PR DESCRIPTION
For those who want to monitor the server status, added a simple health check point.

For example deployed the service with container:
```yaml
healthcheck:
  test: ["CMD", "curl", "-f", "http://localhost:8081/health"]
```
or deployed locally
```sh
node build/index.js --transport streamable --port 8081
MCP ECharts Streamable HTTP server running on http://localhost:8081/mcp

node build/index.js --transport sse --port 8081
MCP ECharts SSE server running on http://localhost:8081/mcp
```

Request:
```bash
# local
curl -f http://localhost:8081/health

# if curl installed
docker exec [container name] curl -f http://localhost:8081/health
```


Response:
```sh
{"status":"healthy","service":"mcp-echarts"}%  
```